### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/image_build.yml
+++ b/.github/workflows/image_build.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       env:
         GROUP_ID: 1000
         USER_ID: 1000


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore